### PR TITLE
Add file path override

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -11,7 +11,7 @@
 # Requires:
 #
 # Sample Usage: netrc::foruser("netrc_myuser": user => 'myuser', machine_user_password_triples => [['myserver.localdomain','myuser','pw'],['mysecondserver.localdomain','myuser','pw2']])
-#
+#               you can also override the path using the `file_path` parameter.
 # [Remember: No empty lines between comments and class definition]
 class netrc {
 
@@ -21,14 +21,15 @@ define netrc::foruser(
   Enum["present", "absent"] $ensure = "present",
   $home_base_directory              = "/home",
   $user,
+  $filename                         = ".netrc",
+  $file_path                        = "$home_base_directory/$user/$filename",
   $machine_user_password_triples) {
 
-  $filename = ".netrc"
 
-  file { "$home_base_directory/$user/$filename":
-    ensure => $ensure,
+  file { "$file_path":
+    ensure  => $ensure,
     content => template('netrc/netrc.erb'),
-    mode => '0600',
-    owner => "$user"
+    mode    => '0600',
+    owner   => "$user"
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -25,7 +25,7 @@ define netrc::foruser(
   Stdlib::Absolutepath          $file_path            = "$home_base_directory/$user/$filename",
   Array                         $machine_user_password_triples) {
 
-  file { "file_path":
+  file { "$file_path":
     ensure  => $ensure,
     content => template('netrc/netrc.erb'),
     mode    => '0600',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -23,7 +23,7 @@ define netrc::foruser(
   String                        $user,
   String                        $filename             = ".netrc",
   Stdlib::Absolutepath          $file_path            = "$home_base_directory/$user/$filename",
-  Array                         $machine_user_password_triples)
+  Array                         $machine_user_password_triples) {
 
   file { "$real_file_path":
     ensure  => $ensure,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -5,28 +5,32 @@
 # Parameters: $user is the useraccount on the machine for which the netrc shall be configured, 
 #				$machine_user_password_triples is an array of arrays containing three string params: machine, user, password
 #				$root_home_directory (optional) is the directory where all user homes are located on the target machine, default value is "/home" 
-#
+#       $file_path (optional) is the absolute path of the .netrc file. 
 # Actions:
 #
 # Requires:
 #
 # Sample Usage: netrc::foruser("netrc_myuser": user => 'myuser', machine_user_password_triples => [['myserver.localdomain','myuser','pw'],['mysecondserver.localdomain','myuser','pw2']])
-#               you can also override the path using the `file_path` parameter.
+#               you can also override the full path by using the `file_path` parameter.
 # [Remember: No empty lines between comments and class definition]
 class netrc {
 
 }
 
 define netrc::foruser(
-  Enum["present", "absent"] $ensure = "present",
-  $home_base_directory              = "/home",
-  $user,
-  $filename                         = ".netrc",
-  $file_path                        = "$home_base_directory/$user/$filename",
+  Enum["present", "absent"]     $ensure = "present",
+  Stdlib::Absolutepath          $home_base_directory  = "/home",
+  String                        $user,
+  String                        $filename             = ".netrc",
+  Optional[Stdlib::Absolutepath] $file_path            = "$home_base_directory/$user/$filename",
   $machine_user_password_triples) {
 
+$real_file_path = $file_path ? {
+    undef   => "$home_base_directory/$user/$filename",
+    default => $file_path
+  }
 
-  file { "$file_path":
+  file { "$real_file_path":
     ensure  => $ensure,
     content => template('netrc/netrc.erb'),
     mode    => '0600',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -25,7 +25,7 @@ define netrc::foruser(
   Stdlib::Absolutepath          $file_path            = "$home_base_directory/$user/$filename",
   Array                         $machine_user_password_triples) {
 
-  file { "$file_path":
+  file { $file_path:
     ensure  => $ensure,
     content => template('netrc/netrc.erb'),
     mode    => '0600',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -25,7 +25,7 @@ define netrc::foruser(
   Stdlib::Absolutepath          $file_path            = "$home_base_directory/$user/$filename",
   Array                         $machine_user_password_triples) {
 
-  file { "$real_file_path":
+  file { "file_path":
     ensure  => $ensure,
     content => template('netrc/netrc.erb'),
     mode    => '0600',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -5,28 +5,32 @@
 # Parameters: $user is the useraccount on the machine for which the netrc shall be configured, 
 #				$machine_user_password_triples is an array of arrays containing three string params: machine, user, password
 #				$root_home_directory (optional) is the directory where all user homes are located on the target machine, default value is "/home" 
-#
+#       $file_path (optional) is the absolute path of the .netrc file. 
 # Actions:
 #
 # Requires:
 #
 # Sample Usage: netrc::foruser("netrc_myuser": user => 'myuser', machine_user_password_triples => [['myserver.localdomain','myuser','pw'],['mysecondserver.localdomain','myuser','pw2']])
-#               you can also override the path using the `file_path` parameter.
+#               you can also override the full path by using the `file_path` parameter.
 # [Remember: No empty lines between comments and class definition]
 class netrc {
 
 }
 
 define netrc::foruser(
-  Enum["present", "absent"] $ensure = "present",
-  $home_base_directory              = "/home",
-  $user,
-  $filename                         = ".netrc",
-  $file_path                        = "$home_base_directory/$user/$filename",
+  Enum["present", "absent"]     $ensure = "present",
+  Stdlib::Absolutepath          $home_base_directory  = "/home",
+  String                        $user,
+  String                        $filename             = ".netrc",
+  Optional[Stdlib::Abolutepath] $file_path            = "$home_base_directory/$user/$filename",
   $machine_user_password_triples) {
 
+$real_file_path = $file_path ? {
+    undef   => "$home_base_directory/$user/$filename",
+    default => $file_path
+  }
 
-  file { "$file_path":
+  file { "$real_file_path":
     ensure  => $ensure,
     content => template('netrc/netrc.erb'),
     mode    => '0600',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -22,13 +22,8 @@ define netrc::foruser(
   Stdlib::Absolutepath          $home_base_directory  = "/home",
   String                        $user,
   String                        $filename             = ".netrc",
-  Optional[Stdlib::Absolutepath] $file_path           = "$home_base_directory/$user/$filename",
-  $machine_user_password_triples) {
-
-$real_file_path = $file_path ? {
-    undef   => "$home_base_directory/$user/$filename",
-    default => $file_path
-  }
+  Stdlib::Absolutepath          $file_path            = "$home_base_directory/$user/$filename",
+  Array                         $machine_user_password_triples)
 
   file { "$real_file_path":
     ensure  => $ensure,


### PR DESCRIPTION
This PR aim to allow a custom path of the .netrc file for service users without home directory
for example: www-data.(apache user)
related [CR](https://fisheye.tuenti.io/cru/CR-LIFE-922)