### PR TITLE
Allow puppet to override params

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -23,7 +23,7 @@ define netrc::foruser(
   String                        $user,
   String                        $filename             = ".netrc",
   Stdlib::Absolutepath          $file_path            = "$home_base_directory/$user/$filename",
-  Array[String, Hash]           $machine_login_password) {
+  Hash[String, Hash]           $machine_login_password) {
 
   file { $file_path:
     ensure  => $ensure,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -5,30 +5,32 @@
 # Parameters: $user is the useraccount on the machine for which the netrc shall be configured, 
 #				$machine_user_password_triples is an array of arrays containing three string params: machine, user, password
 #				$root_home_directory (optional) is the directory where all user homes are located on the target machine, default value is "/home" 
-#
+#       $file_path (optional) is the absolute path of the .netrc file. 
 # Actions:
 #
 # Requires:
 #
 # Sample Usage: netrc::foruser("netrc_myuser": user => 'myuser', machine_user_password_triples => [['myserver.localdomain','myuser','pw'],['mysecondserver.localdomain','myuser','pw2']])
-#
+#               you can also override the full path by using the `file_path` parameter.
 # [Remember: No empty lines between comments and class definition]
 class netrc {
 
 }
 
 define netrc::foruser(
-  Enum["present", "absent"] $ensure = "present",
-  $home_base_directory              = "/home",
-  $user,
-  $machine_user_password_triples) {
+  Enum["present", "absent"]     $ensure = "present",
+  Stdlib::Absolutepath          $home_base_directory  = "/home",
+  String                        $user,
+  String                        $filename             = ".netrc",
+  Stdlib::Absolutepath          $file_path            = "$home_base_directory/$user/$filename",
+  Array[Hash]                   $machine_user_password_triples) {
 
-  $filename = ".netrc"
-
-  file { "$home_base_directory/$user/$filename":
-    ensure => $ensure,
-    content => template('netrc/netrc.erb'),
-    mode => '0600',
-    owner => "$user"
+  file { $file_path:
+    ensure  => $ensure,
+    content => epp('netrc/netrc.epp', {
+      machine_user_password_triples => $machine_user_password_triples
+    }),
+    mode    => '0600',
+    owner   => "$user"
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -23,12 +23,12 @@ define netrc::foruser(
   String                        $user,
   String                        $filename             = ".netrc",
   Stdlib::Absolutepath          $file_path            = "$home_base_directory/$user/$filename",
-  Array[Hash]                   $machine_user_password_triples) {
+  Array[String, Hash]           $machine_login_password) {
 
   file { $file_path:
     ensure  => $ensure,
     content => epp('netrc/netrc.epp', {
-      machine_user_password_triples => $machine_user_password_triples
+      machine_login_password => $machine_login_password
     }),
     mode    => '0600',
     owner   => "$user"

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -23,7 +23,7 @@ define netrc::foruser(
   String                        $user,
   String                        $filename             = ".netrc",
   Stdlib::Absolutepath          $file_path            = "$home_base_directory/$user/$filename",
-  Hash[String, Hash]           $machine_login_password) {
+  Hash[String, Hash]            $machine_login_password) {
 
   file { $file_path:
     ensure  => $ensure,

--- a/templates/netrc.epp
+++ b/templates/netrc.epp
@@ -1,0 +1,3 @@
+<% $machine_user_password_triples.each  |$key, $value| { -%>
+machine <%= $value['machine'] %> login <%= $value['login'] %> password <%= $value['password'] %>
+<%- } -%>

--- a/templates/netrc.epp
+++ b/templates/netrc.epp
@@ -1,3 +1,3 @@
-<% $machine_user_password_triples.each  |$key, $value| { -%>
-machine <%= $value['machine'] %> login <%= $value['login'] %> password <%= $value['password'] %>
+<% $machine_login_password.each  |$machine, $value| { -%>
+machine <%= $machine %> login <%= $value['login'] %> password <%= $value['password'] %>
 <%- } -%>

--- a/templates/netrc.erb
+++ b/templates/netrc.erb
@@ -1,3 +1,0 @@
-<% @machine_user_password_triples.each do |triple| -%>
-machine <%= triple[0] -%> login <%= triple[1] -%> password <%= triple[2] %>
-<% end -%>


### PR DESCRIPTION
we would like for puppet to be able to override an entry and not simply add item in the list.
i've changed the template to epp.
expected tag `v1.2.0`
related to [CR](https://fisheye.tuenti.io/cru/CR-LIFE-986)